### PR TITLE
startup server

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ docker-compose exec startup_server bash
 And on another terminal run:
 ```
 docker-compose exec peer1 bash
-./main.py
+./main.py [STARTUP SERVER NAME]
 ```
 And on another terminal run:
 ```
 docker-compose exec peer2 bash
-./main.py
+./main.py [STARTUP SERVER NAME]
 ```
 
 The containers mount the project directory inside them so all the changes you do will be immediately available containers. You just need to restart the main python script file.

--- a/README.md
+++ b/README.md
@@ -25,16 +25,22 @@ Start two peers. The project's docker-compose config will first fetch the base i
 docker-compose up -d
 ```
 
-After the containers are running, startup our project in the containers manually:
+After the containers are running, startup our project in the containers manually.
+Startup the server first:
 
 ```
-docker-compose exec peer1 bash
-./main.py peer2
+docker-compose exec startup_server bash
+./main.py startup
 ```
-And on another terminal run
+And on another terminal run:
+```
+docker-compose exec peer1 bash
+./main.py
+```
+And on another terminal run:
 ```
 docker-compose exec peer2 bash
-./main.py peer1
+./main.py
 ```
 
 The containers mount the project directory inside them so all the changes you do will be immediately available containers. You just need to restart the main python script file.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,10 @@
 version: '2.1'
 
 services:
+  startup_server:
+    build: ./
+    volumes:
+      - ./:/usr/src/app:rw
   peer1:
     build: ./
     volumes:

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 #!/bin/python3
 
-from socket import AF_INET, SOCK_STREAM, socket as os_socket
+from socket import AF_INET, SOCK_STREAM, gethostname, gethostbyname, socket as os_socket
 import sys
 import json
 import queue
@@ -8,17 +8,23 @@ import logging
 from threading import Thread
 
 APPLICATION_PORT = 65412
+startup = None
 logger = logging.getLogger(__name__)
 logging.basicConfig(filename=f"chat.log", level=logging.DEBUG, format="%(asctime)s - %(message)s")
 
 class Node:
     def __init__(self, hosts, nickname):
         self.message_queue = queue.Queue()
-        self.peer_hosts = hosts
+        self.peer_hosts = hosts if hosts is not None else []
+        self.ip = gethostbyname(gethostname())
         self.nickname = nickname
 
-    def ui(self, peer_port, input=input, socket=os_socket):
+    def ui(self, peer_port, startup, input=input, socket=os_socket):
         try:
+
+            if not startup:
+                self.request_peers(peer_port, socket)
+
             while True:
                 message = input("viestisi: ")
                 for peer_host in self.peer_hosts:
@@ -33,7 +39,7 @@ class Node:
             logger.exception(exc)
             raise exc
 
-    def start_server(self, socket=os_socket):
+    def start_server(self, peer_port, socket=os_socket):
         try:
             with socket(AF_INET, SOCK_STREAM) as s:
                 s.bind(("0.0.0.0", APPLICATION_PORT))
@@ -47,35 +53,86 @@ class Node:
                                 break
                             message = json.loads(data)
                             print()
-                            print(f"Received by {data}")
-                            logger.debug(f"Received by {message['sender']}: {message}")
-                            self.message_queue.put(data)
 
-                            if not self.message_queue.empty():
-                                msg = self.message_queue.get()
+                            if message.get("type") == "GET_NODES":
+                                conn.sendall(json.dumps({"nodes": self.peer_hosts}).encode())
+                                new_peer = message.get("node_ip")
+                                self.peer_hosts.append(new_peer)
+                                print(f"server connected to {self.peer_hosts}")
+                                self.send_peers(peer_port)
+                            elif message.get("type") == "NEW_NODES":
+                                all_peers = set(self.peer_hosts)
+                                new_peers = message.get("nodes", [])
+                                all_peers.update(new_peers)
+                                all_peers.remove(self.ip)
+                                self.peer_hosts = list(all_peers)
+                            else:
+                                print(f"Received by {data}")
+                                logger.debug(f"Received by {message['sender']}: {message}")
+                                self.message_queue.put(data)
 
-                                ack = json.dumps({"type": "ack", "message": f"Received {message['message']} from {message['sender']}", "sender": self.nickname}).encode()
-                                conn.sendall(ack)
-                                logger.debug(f"{self.nickname} sent ack {ack}")
+                                if not self.message_queue.empty():
+                                    msg = self.message_queue.get()
+
+                                    ack = json.dumps({"type": "ack", "message": f"Received {message['message']} from {message['sender']}", "sender": self.nickname}).encode()
+                                    conn.sendall(ack)
+                                    logger.debug(f"{self.nickname} sent ack {ack}")
         except Exception as exc:
             logger.exception(exc)
             raise exc
+
+    def request_peers(self, peer_port, socket=os_socket):
+
+        all_peers = set(self.peer_hosts)
+        try:
+            with socket(AF_INET, SOCK_STREAM) as s:
+                s.connect(("startup_server", peer_port))
+                s.sendall(json.dumps({"type": "GET_NODES", "node_ip": self.ip}).encode())
+                data = s.recv(1024)
+
+                response = json.loads(data)
+                peers = response.get("nodes", [])
+
+                all_peers.update(peers)
+
+        except Exception as exc:
+            logger.error(f"Failed to connect to startup server: {exc}")
+
+        self.peer_hosts = list(all_peers)
+        print(f"Connected to {self.peer_hosts}")
+
+    def send_peers(self, peer_port, socket=os_socket):
+        try:
+            for peer_host in self.peer_hosts:
+                with socket(AF_INET, SOCK_STREAM) as s:
+                    s.connect((peer_host, peer_port))
+                    s.sendall(json.dumps({"type": "NEW_NODES", "nodes": self.peer_hosts}).encode())
+
+        except Exception as exc:
+            logger.error(f"Failed to send new peers: {exc}")
+
 
 # Only run this code if the file was executed from command line
 if __name__ == '__main__':
 
     if '--help' in sys.argv:
-        print(f"Usage: {sys.argv[0]} [PEER_1] [PEER_2] ...")
+        print("Start the startup server:")
+        print(f"Usage: {sys.argv[0]} startup")
         exit(-1)
 
-    peer_hosts = sys.argv[1:] # svm-11-3.cs.helsinki.fi
-    nickname = input("Set nickname: ")
+    if len(sys.argv) > 1 and sys.argv[1] == "startup":
+        startup = 1
+        peer_hosts = None
+        nickname = "startup_server"
+    else:
+        peer_hosts = sys.argv[1:] # svm-11-3.cs.helsinki.fi
+        nickname = input("Set nickname: ")
 
     node = Node(peer_hosts, nickname)
 
     # We are creating separate threads for server and client so that they can run at same time. The sockets api is blocking.
-    t = Thread(target=node.ui, args=[APPLICATION_PORT])
+    t = Thread(target=node.ui, args=[APPLICATION_PORT, startup])
     t.start()
 
-    t = Thread(target=node.start_server, args=[])
+    t = Thread(target=node.start_server, args=[APPLICATION_PORT])
     t.start()


### PR DESCRIPTION
Muutin tapaa millä sovellus käynnistetään, jotta se ymmärtää käynnistää startup serverin hieman eri tavalla kuin muut nodet.. Ohjeet Readme:ssä.

Eli nyt jokainen liittyvä node ottaa yhteyttä startup serveriin, joka kertoo muide nodejen ip-osoitteet. Joka kerta kun systeemiin liittyy uusi node, startup serveri myös lähettää kaikille muille nodeille tiedon uudesta nodesta. Pyrin myös kokoamaan homman niin, että kukaan ei vahingossa ole yhteydessä omaan ip-osoitteeneensa ja self.peer_hosts listassa ei ole duplikaatteja. Ainakin pienellä omalla testailulla näyttäisi toimivan. Pahoittelut, jos koodi on liian spagettia.